### PR TITLE
Rset_info documentation and deployment fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,22 @@
 language: python
 python:
-- 3.9
+  - 3.9
 install:
-- pip install natsort cclib numpy ase mako matplotlib umap-learn
-- pip install pytest-cov codecov furo Sphinx coverage bump2version
-- pip install wheel watchdog tox twine
-- git clone https://github.com/aalexmmaldonado/sGDML
-- cd sGDML
-- git pull
-- git checkout logging
-- pip install .
-- cd ..
+  - pip install natsort cclib numpy ase mako matplotlib umap-learn
+  - pip install pytest-cov codecov furo Sphinx coverage bump2version
+  - pip install wheel watchdog tox twine
+  - git clone https://github.com/aalexmmaldonado/sGDML
+  - cd sGDML
+  - git pull
+  - git checkout logging
+  - pip install .
+  - cd ..
 script:
-- pip install .
-- sphinx-apidoc --force -o docs/source/doc/ mbgdml ./tests/
-- sphinx-build -nT docs/source/ docs/html/
-- touch ./docs/html/.nojekyll
-- pytest --cov=./
+  - pip install .
 after_success:
-- codecov
+  - pytest --cov=./
+  - ./docs/build-docs.sh
+  - codecov
 deploy:
   provider: pages
   skip-cleanup: true
@@ -28,3 +26,4 @@ deploy:
   target_branch: gh-pages
   on:
     branch: main
+    repo: keithgroup/mbGDML

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct dataSet Rset_info documentation.
+
 ## [0.0.1] - 2022-02-24
 
 - Initial release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Only deploy documentation on keithgroup repo.
 - Correct dataSet Rset_info documentation.
 
 ## [0.0.1] - 2022-02-24

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+cd "${0%/*}"
+sphinx-apidoc --force -o ./source/doc/ mbgdml ../tests/
+sphinx-build -nT ./source/ ./html/
+touch ./html/.nojekyll

--- a/mbgdml/data/dataset.py
+++ b/mbgdml/data/dataset.py
@@ -92,16 +92,20 @@ class dataSet(mbGDMLData):
     def Rset_info(self):
         """An array specifying where each structure in R originates from.
 
-        A ``(n_R, 1 + n_z)`` array containing the Rset ID from ``Rset_md5`` in
-        the first column and then the atom indices of the structure with respect
-        to the full structure in the structure set, where ``n_R`` is the number
-        of structures in R and ``n_z`` the number of atoms in each structure in
-        this data set.
+        A ``(n_R, 1 + n_entity)`` array where each row contains the Rset ID
+        from ``Rset_md5`` (e.g., 0, 1, 2, etc.) then the structure index and
+        entity_ids from the original full structure in the structure set.
 
         If there has been no previous sampling, an array of shape (1, 0)
         is returned.
 
         :type: :obj:`numpy.ndarray`
+
+        Examples
+        --------
+        >>> dset.Rset_info  # [Rset_md5_id, r_index, entity_1, entity_2, entity_3]
+        array([[0, 985, 46, 59, 106],
+               [0, 174, 51, 81, 128]])
         """
         if hasattr(self, '_Rset_info'):
             return self._Rset_info


### PR DESCRIPTION
## Small documentation fixes

Data sets contain a ``Rset_info`` attribute that specifies where structures originate from.
The property docstring does correctly describe the format and data.

Also, we change the ``gh-pages`` deployment to only occur on the keithgroup repository.